### PR TITLE
add trailing line required by package.el

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -188,3 +188,4 @@
 
 
 (provide 'restclient)
+;;; restclient.el ends here


### PR DESCRIPTION
Sorry, forgot to add the `ends here` line that package.el needs. 
