### PR TITLE
Support for in-buffer variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # restclient.el
 
-This is a tool to manually explore and test HTTP REST webservices. 
-Runs queries from a plain-text query sheet, 
+This is a tool to manually explore and test HTTP REST webservices.
+Runs queries from a plain-text query sheet,
 displays results as a pretty-printed XML, JSON and even images.
 
 ![](http://i.imgur.com/QtCID.png)
 
 # Usage
 
-Deploy `restclient.el` into your site-lisp as usual, 
-`(require 'restclient)` and prepare a text file with queries. 
+Deploy `restclient.el` into your site-lisp as usual,
+`(require 'restclient)` and prepare a text file with queries.
 
-`restclient-mode` is a major mode which does a bit of highlighting 
+`restclient-mode` is a major mode which does a bit of highlighting
 and supports a few additional keypresses:
 
 - `C-c C-c`: runs the query under the cursor, tries to pretty-print the response (if possible)
@@ -19,53 +19,82 @@ and supports a few additional keypresses:
 
 Query file example:
 
-	# -*- restclient -*-
-	#
-	# Gets user timeline, formats JSON, shows response status and headers underneath
-	#
-	#
-	GET http://api.twitter.com/1/statuses/user_timeline.json?screen_name=twitterapi&count=2
-	#
-	# XML is supported - highlight, pretty-print
-	#
-	GET http://www.redmine.org/issues.xml?limit=10
+        # -*- restclient -*-
+        #
+        # Gets user timeline, formats JSON, shows response status and headers underneath
+        #
+        #
+        GET http://api.twitter.com/1/statuses/user_timeline.json?screen_name=twitterapi&count=2
+        #
+        # XML is supported - highlight, pretty-print
+        #
+        GET http://www.redmine.org/issues.xml?limit=10
 
-	#
-	# It can even show an image!
-	#
-	GET http://upload.wikimedia.org/wikipedia/commons/6/63/Wikipedia-logo.png
-	#
-	# A bit of json GET, you can pass headers too
-	#
-	GET http://jira.atlassian.com/rest/api/latest/issue/JRA-9
-	User-Agent: Emacs24
-	Accept-Encoding: application/xml
+        #
+        # It can even show an image!
+        #
+        GET http://upload.wikimedia.org/wikipedia/commons/6/63/Wikipedia-logo.png
+        #
+        # A bit of json GET, you can pass headers too
+        #
+        GET http://jira.atlassian.com/rest/api/latest/issue/JRA-9
+        User-Agent: Emacs24
+        Accept-Encoding: application/xml
 
-	#
-	# Post works too, entity just goes after an empty line. Same is for PUT.
-	#
-	POST https://jira.atlassian.com/rest/api/2/search
-	Content-Type: application/json
+        #
+        # Post works too, entity just goes after an empty line. Same is for PUT.
+        #
+        POST https://jira.atlassian.com/rest/api/2/search
+        Content-Type: application/json
 
-	{
-		"jql": "project = HSP",
-		"startAt": 0,
-		"maxResults": 15,
-		"fields": [
-			"summary",
-			"status",
-			"assignee"
-		]
-	}
-	#
-	# And delete, will return not-found error...
-	#
-	DELETE https://jira.atlassian.com/rest/api/2/version/20
+        {
+                "jql": "project = HSP",
+                "startAt": 0,
+                "maxResults": 15,
+                "fields": [
+                        "summary",
+                        "status",
+                        "assignee"
+                ]
+        }
+        #
+        # And delete, will return not-found error...
+        #
+        DELETE https://jira.atlassian.com/rest/api/2/version/20
 
 
-Lines starting with `#` are considered comments AND also act as separators. 
+Lines starting with `#` are considered comments AND also act as separators.
 
 HTTPS and image display requires additional dll's on windows (libtls, libpng, libjpeg etc), which are not in the emacs distribution.
+
+# In-buffer variables
+
+You declare a variable like this:
+
+    :myvar = the value
+
+After the var is declared, you can use it in the URL, the header values
+and the body.
+
+    # Some generic vars
+
+    :my-auth = 319854857345898457457
+
+    # Update a user's name
+
+    :user-id = 7
+    :the-name = Neo
+
+    PUT http://localhost:4000/users/:user-id/
+    Authorization: :my-auth
+
+    { "name": ":the-name" }
+
+Warning: If you include var declarations as part of the request, in
+the body or headers, it will be sent along.
+
+Instead, place them above your calls or in separate sections. Like in
+the example above.
 
 # Known issues
 

--- a/restclient.el
+++ b/restclient.el
@@ -173,6 +173,9 @@
 (defconst restclient-header-regexp
   "^\\([^ :]+\\): \\(.*\\)$")
 
+(defconst restclient-var-regexp
+  "^\\(:[^: ]+\\) = \\(.+\\)$")
+
 (defun restclient-current-min ()
   (save-excursion
 	(beginning-of-line)
@@ -189,6 +192,28 @@
 		(point-at-bol)
 	  (point-max))))
 
+(defun restclient-replace-all-in-string (replacements s)
+  (replace-regexp-in-string (regexp-opt (mapcar 'car replacements))
+                            (lambda (key) (cdr (assoc key replacements)))
+                            s))
+
+(defun restclient-replace-all-in-header (replacements header)
+  (cons (car header)
+        (restclient-replace-all-in-string replacements (cdr header))))
+
+(defun restclient-replace-all-in-headers (replacements headers)
+  (mapcar (apply-partially 'restclient-replace-all-in-header vars) headers))
+
+(defun restclient-find-vars-before-point ()
+  (let ((vars nil)
+        (bound (point)))
+    (save-excursion
+      (goto-char (point-min))
+      (while (search-forward-regexp restclient-var-regexp bound t)
+        (let ((name (buffer-substring-no-properties (match-beginning 1) (match-end 1)))
+              (value (buffer-substring-no-properties (match-beginning 2) (match-end 2))))
+          (setq vars (cons (cons name value) vars))))
+      vars)))
 
 ;;;###autoload
 (defun restclient-http-send-current (&optional raw)
@@ -207,7 +232,11 @@
 			  (forward-line))
 			(when (looking-at "^\\s-*$")
 			  (forward-line))
-			(let ((entity (buffer-substring (point) (restclient-current-max))))
+			(let* ((entity (buffer-substring (point) (restclient-current-max)))
+			       (vars (restclient-find-vars-before-point))
+			       (url (restclient-replace-all-in-string vars url))
+			       (headers (restclient-replace-all-in-headers vars headers))
+			       (entity (restclient-replace-all-in-string vars entity)))
 			  (message "HTTP %s %s Headers:[%s] Body:[%s]" method url headers entity)
 			  (restclient-http-do method url headers entity raw))))))
 
@@ -219,7 +248,7 @@
 (setq restclient-mode-keywords
 	  (list (list restclient-method-url-regexp '(1 font-lock-keyword-face) '(2 font-lock-function-name-face))
 			(list restclient-header-regexp '(1 font-lock-variable-name-face) '(2 font-lock-string-face))
-
+			(list restclient-var-regexp '(1 font-lock-variable-name-face) '(2 font-lock-string-face))
 			))
 
 (defvar restclient-mode-syntax-table


### PR DESCRIPTION
Like we talked about in #16 :-) Here from the updated README:

You declare a variable like this:

```
:myvar = the value
```

After the var is declared, you can use it in the URL, the header values
and the body.

```
# Some generic vars

:my-auth = 319854857345898457457

# Update a user's name

:user-id = 7
:the-name = Neo

PUT http://localhost:4000/users/:user-id/
Authorization: :my-auth

{ "name": ":the-name" }
```

Warning: If you include var declarations as part of the request, in
the body or headers, it will be sent along.

Instead, place them above your calls or in separate sections. Like in
the example above.
