### PR TITLE
Prettify application/atom+xml as XML

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -84,6 +84,7 @@
 					  (buffer-substring-no-properties (match-beginning 1) (match-end 1))
 					  '(("text/xml" . xml-mode)
 						("application/xml" . xml-mode)
+						("application/atom+xml" . xml-mode)
 						("application/json" . js-mode)
 						("image/png" . image-mode)
 						("image/jpeg" . image-mode)


### PR DESCRIPTION
Entities with content-type application/atom+xml were not prettified as XML, this should fix that.
