### PR TITLE
Format application/atomcat+xml as XML

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -85,6 +85,7 @@
 					  '(("text/xml" . xml-mode)
 						("application/xml" . xml-mode)
 						("application/atom+xml" . xml-mode)
+                                                ("application/atomcat+xml" . xml-mode)
 						("application/json" . js-mode)
 						("image/png" . image-mode)
 						("image/jpeg" . image-mode)


### PR DESCRIPTION
The application/atomcat+xml media type is described in RFC 5023, and should be formatted as XML.
