### PR TITLE
Trim excess whitespace from post body

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Query file example:
 	#
 	# User details
 	#
-	GET http://91.206.1.172/webservices/user/aba?sessionId=1330619005027
+	GET http://somehost.com/webservic/user/aba?sessionId=1330619005027
 	Authorization: token=dfsdsffffffffffffff234435lkjsdfl
 
 	#

--- a/README.md
+++ b/README.md
@@ -4,6 +4,34 @@ This is a tool to manually explore and test HTTP REST webservices. Runs queries 
 
 # Usage
 
-Deploy restclient.el into your site-lisp as usual, require it and make a text file with queries. C-c C-c runs the one under the cursor.
+Deploy restclient.el into your site-lisp as usual, require it and make a text file with queries. C-c C-c runs the query under the cursor.
+
+Query file example:
+
+	# -*- restclient -*-
+	#
+	# Sync test
+	#
+	POST http://somehost.com/webservic/user/aba/sync?session=1331294083924
+	Authorization: token=dfsdsffffffffffffff234435lkjsdfl
+	X-HTTP-Method: PUT
+
+	<?xml version="1.0" encoding="UTF-8"?><Update id="716762662"><items></items></Update>
+
+	#
+	# User details
+	#
+	GET http://91.206.1.172/webservices/user/aba?sessionId=1330619005027
+	Authorization: token=dfsdsffffffffffffff234435lkjsdfl
+
+	#
+	#
+	GET http://api.twitter.com/1/statuses/user_timeline.json?include_entities=true&include_rts=true&screen_name=twitterapi&count=2
+	#
+	#
+	GET http://img.yandex.net/i/www/logo.png
 
 
+Lines starting with `#` are considered comments AND also act as separators. Yes, that means you can't post shell script as PUT entity. But I don't care. 
+
+HTTPS and image display requires additional dll's on windows (libtls, libpng, libjpeg etc), which are not in the emacs distribution.

--- a/README.md
+++ b/README.md
@@ -1,37 +1,72 @@
 # restclient.el
 
-This is a tool to manually explore and test HTTP REST webservices. Runs queries from a plain-text query sheet, displays results as a pretty-printed XML, JSON and even images.
+This is a tool to manually explore and test HTTP REST webservices. 
+Runs queries from a plain-text query sheet, 
+displays results as a pretty-printed XML, JSON and even images.
 
 # Usage
 
-Deploy restclient.el into your site-lisp as usual, require it and make a text file with queries. C-c C-c runs the query under the cursor.
+Deploy `restclient.el` into your site-lisp as usual, 
+`(require 'restclient)` and prepare a text file with queries. 
+
+`restclient-mode` is a major mode which does a bit of highlighting 
+and supports a few additional keypresses:
+
+- `C-c C-c`: runs the query under the cursor, tries to pretty-print the response (if possible)
+- `C-c C-r`: same, but doesn't do anything with the response, just shows the buffer
 
 Query file example:
 
 	# -*- restclient -*-
 	#
-	# Sync test
+	# Gets user timeline, formats JSON, shows response status and headers underneath
 	#
-	POST http://somehost.com/webservic/user/aba/sync?session=1331294083924
-	Authorization: token=dfsdsffffffffffffff234435lkjsdfl
-	X-HTTP-Method: PUT
-
-	<?xml version="1.0" encoding="UTF-8"?><Update id="716762662"><items></items></Update>
-
 	#
-	# User details
+	GET http://api.twitter.com/1/statuses/user_timeline.json?screen_name=twitterapi&count=2
 	#
-	GET http://somehost.com/webservic/user/aba?sessionId=1330619005027
-	Authorization: token=dfsdsffffffffffffff234435lkjsdfl
+	# XML is supported - highlight, pretty-print
+	#
+	GET http://www.redmine.org/issues.xml?limit=10
 
 	#
+	# It can even show an image!
 	#
-	GET http://api.twitter.com/1/statuses/user_timeline.json?include_entities=true&include_rts=true&screen_name=twitterapi&count=2
+	GET http://upload.wikimedia.org/wikipedia/commons/6/63/Wikipedia-logo.png
 	#
+	# A bit of json GET, you can pass headers too
 	#
-	GET http://img.yandex.net/i/www/logo.png
+	GET http://jira.atlassian.com/rest/api/latest/issue/JRA-9
+	User-Agent: Emacs24
+	Accept-Encoding: application/xml
+
+	#
+	# Post works too, entity just goes after an empty line. Same is for PUT.
+	#
+	POST https://jira.atlassian.com/rest/api/2/search
+	Content-Type: application/json
+
+	{
+		"jql": "project = HSP",
+		"startAt": 0,
+		"maxResults": 15,
+		"fields": [
+			"summary",
+			"status",
+			"assignee"
+		]
+	}
+	#
+	# And delete, will return not-found error...
+	#
+	DELETE https://jira.atlassian.com/rest/api/2/version/20
 
 
-Lines starting with `#` are considered comments AND also act as separators. Yes, that means you can't post shell script as PUT entity. But I don't care. 
+Lines starting with `#` are considered comments AND also act as separators. 
 
 HTTPS and image display requires additional dll's on windows (libtls, libpng, libjpeg etc), which are not in the emacs distribution.
+
+# Known issues
+
+- Comment lines `#` act as end of enitity. Yes, that means you can't post shell script or anything with hashes as PUT/POST entity. I'm fine with this right now,
+but may use more unique separator in future.
+- I'm not sure if it handles different encodings, I suspect it won't play well with anything non-ascii. I'm yet to figure it out.

--- a/README.md
+++ b/README.md
@@ -70,3 +70,12 @@ HTTPS and image display requires additional dll's on windows (libtls, libpng, li
 - Comment lines `#` act as end of enitity. Yes, that means you can't post shell script or anything with hashes as PUT/POST entity. I'm fine with this right now,
 but may use more unique separator in future.
 - I'm not sure if it handles different encodings, I suspect it won't play well with anything non-ascii. I'm yet to figure it out.
+
+# License
+
+Public domain, do whatever you want (apart from json-reformat.el thing, which is not mine)
+
+# Author
+
+Pavel Kurnosov <pashky@gmail.com>
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a tool to manually explore and test HTTP REST webservices.
 Runs queries from a plain-text query sheet, 
 displays results as a pretty-printed XML, JSON and even images.
 
+(http://i.imgur.com/QtCID.png)
+
 # Usage
 
 Deploy `restclient.el` into your site-lisp as usual, 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a tool to manually explore and test HTTP REST webservices.
 Runs queries from a plain-text query sheet, 
 displays results as a pretty-printed XML, JSON and even images.
 
-(http://i.imgur.com/QtCID.png)
+![](http://i.imgur.com/QtCID.png)
 
 # Usage
 

--- a/json-reformat.el
+++ b/json-reformat.el
@@ -1,0 +1,72 @@
+(require 'json)
+;; JSON reformat snippet
+;; from https://gist.github.com/1789605
+
+(defun json-reformat:indent (level)
+  (make-string (* level 4) ? ))
+
+(defun json-reformat:p-of-number (val)
+  (number-to-string val))
+
+(defun json-reformat:p-of-list (val level)
+  (concat "{\n" (json:list-to-string val (1+ level)) (json-reformat:indent level) "}"))
+
+(defun json-reformat:p-of-vector (val level)
+  (if (= (length val) 0) "[]"
+    (concat "[\n"
+            (mapconcat
+             'identity
+             (loop for v across val
+                   collect (concat
+                            (json-reformat:indent (1+ level))
+                            (json-reformat:print-value v (1+ level))
+                            ))
+             (concat ",\n"))
+            "\n" (json-reformat:indent level) "]"
+            )))
+
+(defun json-reformat:p-of-symbol (val)
+  (cond ((equal 't val) "true")
+        ((equal json-false val) "false")
+        (t (symbol-name val))))
+
+(defun json-reformat:print-value (val level)
+  (cond ((consp val) (json-reformat:p-of-list val level))
+        ((numberp val) (json-reformat:p-of-number val))
+        ((vectorp val) (json-reformat:p-of-vector val level))
+        ((null val) "\"\"")
+        ((symbolp val) (json-reformat:p-of-symbol val))
+        (t (concat "\"" val "\""))))
+
+(defun json:list-to-string (root level)
+  (let (key val str)
+    (while root
+      (setq key (car root)
+            val (cadr root)
+            root (cddr root))
+      (setq str
+            (concat str (json-reformat:indent level)
+                    "\"" key "\""
+                    ": "
+                    (json-reformat:print-value val level)
+                    (when root ",")
+                    "\n"
+                    )))
+    str))
+
+(defun json-reformat-region (begin end)
+  (interactive "r")
+  (save-excursion
+    (save-restriction
+      (narrow-to-region begin end)
+      (goto-char (point-min))
+      (let* ((json-key-type 'string)
+             (json-object-type 'plist)
+             (before (buffer-substring (point-min) (point-max)))
+             (json-tree (json-read-from-string before))
+             after)
+        (setq after (json-reformat:print-value json-tree 0))
+        (delete-region (point-min) (point-max))
+        (insert after)))))
+
+(provide 'json-reformat)

--- a/json-reformat.el
+++ b/json-reformat.el
@@ -38,7 +38,7 @@
         ((vectorp val) (json-reformat:p-of-vector val level))
         ((null val) "null")
         ((symbolp val) (json-reformat:p-of-symbol val))
-        (t (concat "\"" val "\""))))
+        (t (json-encode-string val))))
 
 (defun json:list-to-string (root level)
   (let (key val str)

--- a/json-reformat.el
+++ b/json-reformat.el
@@ -1,6 +1,8 @@
-(require 'json)
 ;; JSON reformat snippet
 ;; from https://gist.github.com/1789605
+
+(require 'json)
+(require 'cl)
 
 (defun json-reformat:indent (level)
   (make-string (* level 4) ? ))

--- a/restclient.el
+++ b/restclient.el
@@ -5,7 +5,7 @@
 ;; Author: Pavel Kurnosov <pashky@gmail.com>
 ;; Maintainer: Pavel Kurnosov <pashky@gmail.com>
 ;; Created: 01 Apr 2012
-;; Keywords: languages
+;; Keywords: http
      
 ;; This file is not part of GNU Emacs.
 ;; This file is public domain software. Do what you want.

--- a/restclient.el
+++ b/restclient.el
@@ -36,7 +36,7 @@
 				  (list (if restclient-same-buffer-response
 							restclient-same-buffer-response-name
 						  (format "*HTTP %s %s*" method url)) raw)
-				  nil t)))
+				  )))
 
 (defun restclient-prettify-response ()
   (save-excursion

--- a/restclient.el
+++ b/restclient.el
@@ -193,9 +193,11 @@
 	  (point-max))))
 
 (defun restclient-replace-all-in-string (replacements s)
-  (replace-regexp-in-string (regexp-opt (mapcar 'car replacements))
-                            (lambda (key) (cdr (assoc key replacements)))
-                            s))
+  (if replacements 
+      (replace-regexp-in-string (regexp-opt (mapcar 'car replacements))
+                                (lambda (key) (cdr (assoc key replacements)))
+                                s)
+    s))
 
 (defun restclient-replace-all-in-header (replacements header)
   (cons (car header)

--- a/restclient.el
+++ b/restclient.el
@@ -26,6 +26,13 @@
   (setq restclient-within-call nil))
 (ad-activate 'url-http-handle-authentication)
 
+(defadvice url-cache-extract (around restclient-fix-2)
+  (if restclient-within-call
+	  (setq success t)
+	ad-do-it)
+  (setq restclient-within-call nil))
+(ad-activate 'url-cache-extract)
+
 (defun restclient-http-do (method url headers entity raw)
   "Send ARGS to URL as a POST request."
   (let* ((url-request-method method)

--- a/restclient.el
+++ b/restclient.el
@@ -219,6 +219,12 @@
           (setq vars (cons (cons name value) vars))))
       vars)))
 
+(defun restclient-trim-right (s)
+  "Remove whitespace at the end of S."
+  (if (string-match "[ \t\n\r]+\\'" s)
+      (replace-match "" t t s)
+    s))
+
 ;;;###autoload
 (defun restclient-http-send-current (&optional raw)
   (interactive)
@@ -236,7 +242,7 @@
 			  (forward-line))
 			(when (looking-at "^\\s-*$")
 			  (forward-line))
-			(let* ((entity (buffer-substring (point) (restclient-current-max)))
+			(let* ((entity (restclient-trim-right (buffer-substring (point) (restclient-current-max))))
 			       (vars (restclient-find-vars-before-point))
 			       (url (restclient-replace-all-in-string vars url))
 			       (headers (restclient-replace-all-in-headers vars headers))

--- a/restclient.el
+++ b/restclient.el
@@ -1,8 +1,14 @@
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; HTTP REST client
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Author: pashky@gmail.com
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; restclient.el --- An interactive HTTP client for Emacs
+     
+;; Public domain.
+     
+;; Author: Pavel Kurnosov <pashky@gmail.com>
+;; Maintainer: Pavel Kurnosov <pashky@gmail.com>
+;; Created: 01 Apr 2012
+;; Keywords: languages
+     
+;; This file is not part of GNU Emacs.
+;; This file is public domain software. Do what you want.
 
 (require 'url)
 (require 'json-reformat)

--- a/restclient.el
+++ b/restclient.el
@@ -5,7 +5,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (require 'url)
-(require 'json)
+(require 'json-reformat)
 
 (defcustom restclient-same-buffer-response t
   "Re-use same buffer for responses or create a new one each time")
@@ -163,74 +163,5 @@
 
   (set (make-local-variable 'font-lock-defaults) '(restclient-mode-keywords)))
 
-;; JSON reformat snippet
-;; from https://gist.github.com/1789605
-
-(defun json-reformat:indent (level)
-  (make-string (* level 4) ? ))
-
-(defun json-reformat:p-of-number (val)
-  (number-to-string val))
-
-(defun json-reformat:p-of-list (val level)
-  (concat "{\n" (json:list-to-string val (1+ level)) (json-reformat:indent level) "}"))
-
-(defun json-reformat:p-of-vector (val level)
-  (if (= (length val) 0) "[]"
-    (concat "[\n"
-            (mapconcat
-             'identity
-             (loop for v across val
-                   collect (concat
-                            (json-reformat:indent (1+ level))
-                            (json-reformat:print-value v (1+ level))
-                            ))
-             (concat ",\n"))
-            "\n" (json-reformat:indent level) "]"
-            )))
-
-(defun json-reformat:p-of-symbol (val)
-  (cond ((equal 't val) "true")
-        ((equal json-false val) "false")
-        (t (symbol-name val))))
-
-(defun json-reformat:print-value (val level)
-  (cond ((consp val) (json-reformat:p-of-list val level))
-        ((numberp val) (json-reformat:p-of-number val))
-        ((vectorp val) (json-reformat:p-of-vector val level))
-        ((null val) "\"\"")
-        ((symbolp val) (json-reformat:p-of-symbol val))
-        (t (concat "\"" val "\""))))
-
-(defun json:list-to-string (root level)
-  (let (key val str)
-    (while root
-      (setq key (car root)
-            val (cadr root)
-            root (cddr root))
-      (setq str
-            (concat str (json-reformat:indent level)
-                    "\"" key "\""
-                    ": "
-                    (json-reformat:print-value val level)
-                    (when root ",")
-                    "\n"
-                    )))
-    str))
-
-(defun json-reformat-region (begin end)
-  (interactive "r")
-  (save-excursion
-    (save-restriction
-      (narrow-to-region begin end)
-      (goto-char (point-min))
-      (let* ((json-key-type 'string)
-             (json-object-type 'plist)
-             (before (buffer-substring (point-min) (point-max)))
-             (json-tree (json-read-from-string before))
-             after)
-        (setq after (json-reformat:p-of-list json-tree 0))
-        (delete-region (point-min) (point-max))
-        (insert after)))))
 
 (provide 'restclient)


### PR DESCRIPTION
The way restclient handles post body, leaves some whitespace at the end.
I'm using an API now that doesn't trim properly. This fixes that.

Hopefully people aren't relying on sending spaces and newlines at the end of a post body. What do you think?