### PR TITLE
Add support for elisp expressions for variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ You declare a variable like this:
 
     :myvar = the value
 
+Variables can also be assigned values from an elisp expression
+
+    :myvar = (base64-encode-string "username:password" t)
+
 After the var is declared, you can use it in the URL, the header values
 and the body.
 

--- a/restclient.el
+++ b/restclient.el
@@ -223,7 +223,8 @@
       (while (search-forward-regexp restclient-var-regexp bound t)
         (let ((name (buffer-substring-no-properties (match-beginning 1) (match-end 1)))
               (value (buffer-substring-no-properties (match-beginning 2) (match-end 2))))
-          (setq vars (cons (cons name value) vars))))
+          (let ((expr (ignore-errors (eval (read value)))))
+            (setq vars (cons (cons name (if expr expr value)) vars)))))
       vars)))
 
 ;;;###autoload


### PR DESCRIPTION
This is handy if you want to for example build up an authorization
header from some secrets you can get via elisp. If the string cannot be
parsed and evaluated then it's just treated as a normal string.
