### PR TITLE
Replace `font-lock-fontify-buffer` with font-lock-ensure and resolve free variable issue

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -121,7 +121,9 @@
           (delete-region start (point))
           (unless (eq guessed-mode 'image-mode)
             (apply guessed-mode '())
-            (font-lock-fontify-buffer))
+            (funcall (if (fboundp 'font-lock-ensure)
+                         #'font-lock-ensure
+                       #'font-lock-fontify-buffer)))
 
           (cond
            ((eq guessed-mode 'xml-mode)
@@ -242,7 +244,7 @@
         (restclient-replace-all-in-string replacements (cdr header))))
 
 (defun restclient-replace-all-in-headers (replacements headers)
-  (mapcar (apply-partially 'restclient-replace-all-in-header vars) headers))
+  (mapcar (apply-partially 'restclient-replace-all-in-header replacements) headers))
 
 (defun restclient-find-vars-before-point ()
   (let ((vars nil)


### PR DESCRIPTION
Can you check if `font-lock-ensure` is sufficient?
As the documentation for `font-lock-fontify-buffer` says:

```
When called from Lisp, this function is a big mess.  The caller usually
expects one of the following behaviors:
- refresh the highlighting (because the font-lock-keywords have been
  changed).
- apply font-lock highlighting even if font-lock-mode is not enabled.
- reset the highlighting rules because font-lock-defaults
  has been changed (and then rehighlight everything).
Of course, this function doesn't do all of the above in all situations
(e.g. depending on whether jit-lock is in use) and it can't guess what
the caller wants.
```

In `restclient-replace-all-in-headers` replace the free variable `vars`
with `replacements`.

[![24pullrequests](http://24pullrequests.com/assets/logo-625222452ffc0d57272decb6f851a7fe.png)](http://24pullrequests.com)

Best,
Markus
