### PR TITLE
Fix README (decrease code block indent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,48 +27,48 @@ and supports a few additional keypresses:
 
 Query file example:
 
-        # -*- restclient -*-
-        #
-        # Gets user timeline, formats JSON, shows response status and headers underneath
-        #
-        #
-        GET http://api.twitter.com/1/statuses/user_timeline.json?screen_name=twitterapi&count=2
-        #
-        # XML is supported - highlight, pretty-print
-        #
-        GET http://www.redmine.org/issues.xml?limit=10
+    # -*- restclient -*-
+    #
+    # Gets user timeline, formats JSON, shows response status and headers underneath
+    #
+    #
+    GET http://api.twitter.com/1/statuses/user_timeline.json?screen_name=twitterapi&count=2
+    #
+    # XML is supported - highlight, pretty-print
+    #
+    GET http://www.redmine.org/issues.xml?limit=10
 
-        #
-        # It can even show an image!
-        #
-        GET http://upload.wikimedia.org/wikipedia/commons/6/63/Wikipedia-logo.png
-        #
-        # A bit of json GET, you can pass headers too
-        #
-        GET http://jira.atlassian.com/rest/api/latest/issue/JRA-9
-        User-Agent: Emacs24
-        Accept-Encoding: application/xml
+    #
+    # It can even show an image!
+    #
+    GET http://upload.wikimedia.org/wikipedia/commons/6/63/Wikipedia-logo.png
+    #
+    # A bit of json GET, you can pass headers too
+    #
+    GET http://jira.atlassian.com/rest/api/latest/issue/JRA-9
+    User-Agent: Emacs24
+    Accept-Encoding: application/xml
 
-        #
-        # Post works too, entity just goes after an empty line. Same is for PUT.
-        #
-        POST https://jira.atlassian.com/rest/api/2/search
-        Content-Type: application/json
+    #
+    # Post works too, entity just goes after an empty line. Same is for PUT.
+    #
+    POST https://jira.atlassian.com/rest/api/2/search
+    Content-Type: application/json
 
-        {
-                "jql": "project = HSP",
-                "startAt": 0,
-                "maxResults": 15,
-                "fields": [
-                        "summary",
-                        "status",
-                        "assignee"
-                ]
-        }
-        #
-        # And delete, will return not-found error...
-        #
-        DELETE https://jira.atlassian.com/rest/api/2/version/20
+    {
+            "jql": "project = HSP",
+            "startAt": 0,
+            "maxResults": 15,
+            "fields": [
+                    "summary",
+                    "status",
+                    "assignee"
+            ]
+    }
+    #
+    # And delete, will return not-found error...
+    #
+    DELETE https://jira.atlassian.com/rest/api/2/version/20
 
 
 Lines starting with `#` are considered comments AND also act as separators.


### PR DESCRIPTION
Github markdown renders redundant space.

## Before

![Before](https://cloud.githubusercontent.com/assets/822086/5690496/12d3d968-98d1-11e4-9c52-7eca42a683f4.png)

## After

![After](https://cloud.githubusercontent.com/assets/822086/5690497/12d76d80-98d1-11e4-9f95-ea4c04b6032c.png)