### PR TITLE
Enable to toggle implicit cookies

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -33,6 +33,11 @@
   :group 'restclient
   :type 'string)
 
+(defcustom restclient-inhibit-cookies nil
+  "Inhibit restclient from sending cookies implicitly"
+  :group 'restclient
+  :type 'boolean)
+
 (defvar restclient-within-call nil)
 
 (defvar restclient-request-time-start nil)
@@ -93,7 +98,7 @@
     (url-retrieve url 'restclient-http-handle-response
                   (list method url (if restclient-same-buffer-response
                             restclient-same-buffer-response-name
-                          (format "*HTTP %s %s*" method url)) raw stay-in-window))))
+                          (format "*HTTP %s %s*" method url)) raw stay-in-window) nil restclient-inhibit-cookies)))
 
 (defvar restclient-content-type-regexp "^Content-[Tt]ype: \\(\\w+\\)/\\(?:[^\\+\r\n]*\\+\\)*\\([^;\r\n]+\\)")
 


### PR DESCRIPTION
Hello.
I'm a big fan of restclient.el.

Recently, I've been using it to test some APIs which are only available with session cookie.
Then I found that restclient.el sends cookies, though ```Cookie:``` header wasn't contained in a request buffer.
This is default behavior of ```url-retrieve``` , which is called internally in restclient.el.

I feel it is a bit confusing and there might be some case in which user wants to call API without cookies,
so I'd like to toggle whether to use implicit cookies or not.