### PR TITLE
Fix byte-compile warning about using free variable

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -356,12 +356,12 @@
   (backward-char 1)
   (setq deactivate-mark nil))
 
-(setq restclient-mode-keywords
-      (list (list restclient-method-url-regexp '(1 font-lock-keyword-face) '(2 font-lock-function-name-face))
-            (list restclient-header-regexp '(1 font-lock-variable-name-face) '(2 font-lock-string-face))
-            (list restclient-evar-regexp '(1 font-lock-preprocessor-face) '(2 font-lock-function-name-face))
-            (list restclient-var-regexp '(1 font-lock-preprocessor-face) '(3 font-lock-string-face))
-            ))
+(defvar restclient-mode-keywords
+  (list (list restclient-method-url-regexp '(1 font-lock-keyword-face) '(2 font-lock-function-name-face))
+        (list restclient-header-regexp '(1 font-lock-variable-name-face) '(2 font-lock-string-face))
+        (list restclient-evar-regexp '(1 font-lock-preprocessor-face) '(2 font-lock-function-name-face))
+        (list restclient-var-regexp '(1 font-lock-preprocessor-face) '(3 font-lock-string-face))
+        ))
 
 (defvar restclient-mode-syntax-table
   (let ((table (make-syntax-table)))


### PR DESCRIPTION
I got following  byte-compile warning. This patch fixes this.

```
restclient.el:359:7:Warning: assignment to free variable
    `restclient-mode-keywords'
```