### PR TITLE
Parse only \u and following 4 characters as a unicode character.

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -176,7 +176,7 @@
 (defun restclient-prettify-json-unicode ()
   (save-excursion
     (goto-char (point-min))
-    (while (re-search-forward "\\\\[Uu]\\([0-9a-fA-F]\\{4\\}+\\)" nil t)
+    (while (re-search-forward "\\\\[Uu]\\([0-9a-fA-F]\\{4\\}\\)" nil t)
       (replace-match (char-to-string (decode-char 'ucs (string-to-number (match-string 1) 16))) t nil))))
 
 (defun restclient-http-handle-response (status method url bufname raw stay-in-window)


### PR DESCRIPTION
The original code failed to parse a JSON string such that 4 or more Hex characters ([0-9a-fA-F])  follow after a unicode character, like `"\u984c1000"` (It represents "題1000").

This change make sure that only 4 characters after `\u` are parsed as a unicode codepoint to fix the issue (opened as #80).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pashky/restclient.el/79)
<!-- Reviewable:end -->
