### PR TITLE
Add function for generating new rest-client buffer

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -332,6 +332,15 @@
       (message "curl command copied to clipboard."))))
 
 ;;;###autoload
+(defun restclient-new-buffer ()
+  (interactive)
+  (let ((buffer (generate-new-buffer "*rest-client*")))
+    (with-current-buffer buffer
+      (insert "# -*- restclient -*- \n\n")
+      (restclient-mode)
+      (pop-to-buffer buffer))))
+
+;;;###autoload
 (defun restclient-http-send-current (&optional raw stay-in-window)
   (interactive)
   (restclient-http-parse-current-and-do 'restclient-http-do raw stay-in-window))


### PR DESCRIPTION
My usual workflow for using restclient is to create a new buffer, switch
on restclient-mode, and begin using restclient. This function is a handy
helper for doing that quickly.