### PR TITLE
Replace obsolete Twitter API example with Github API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ Query file example:
 
     # -*- restclient -*-
     #
-    # Gets user timeline, formats JSON, shows response status and headers underneath
+    # Gets  all Github APIs, formats JSON, shows response status and headers underneath.
+    # Also sends a User-Agent header, because the Github API requires this.
     #
-    #
-    GET http://api.twitter.com/1/statuses/user_timeline.json?screen_name=twitterapi&count=2
+    GET https://api.github.com
+    User-Agent: Emacs Restclient
+
     #
     # XML is supported - highlight, pretty-print
     #


### PR DESCRIPTION
The Twitter example used the old API v1 which is not online anymore. Also the new API requires OAuth authentication.

I do realise that you wanted an easy as it get's example on the first line. The Github example doesn't qualify 100% since it also sends a Header. An alternative could be `GET http://jsonip.com`, but I prefered Github, since the API is probably more certain to stay online and accessible.