### PR TITLE
Fix package

### DIFF
--- a/helm-restclient.el
+++ b/helm-restclient.el
@@ -23,7 +23,10 @@
 (defun restclient-helm-find-candidates-matching (regexp process)
   (let ((result '()))
     (with-helm-current-buffer
-      (font-lock-ensure)
+      (if (fboundp 'font-lock-ensure)
+          (font-lock-ensure)
+        (with-no-warnings
+          (font-lock-fontify-buffer)))
       (save-excursion
         (goto-char (point-min))
         (while (re-search-forward regexp nil t)

--- a/helm-restclient.el
+++ b/helm-restclient.el
@@ -1,4 +1,4 @@
-;;; restclient.el --- An interactive HTTP client for Emacs
+;;; helm-restclient.el --- helm interface for restclient.el
 ;;
 ;; Public domain.
 

--- a/helm-restclient.el
+++ b/helm-restclient.el
@@ -17,6 +17,7 @@
 ;;; Code:
 ;;
 (require 'helm)
+(require 'helm-utils)
 (require 'restclient)
 
 (defun restclient-helm-find-candidates-matching (regexp process)


### PR DESCRIPTION
- Correct package header
- Load helm-utils for using `helm-goto-line`
- Fix for older Emacs about using `font-lock-ensure`.

There are following byte-compile warnings in original code on Emacs 24.5.

```
helm-restclient.el:72:1:Warning: the following functions are not known to be defined:
    font-lock-ensure, helm-goto-line
```