### PR TITLE
Use content-type to guess if we receive binary data.

### DIFF
--- a/examples/httpbin
+++ b/examples/httpbin
@@ -36,6 +36,9 @@ GET http://httpbin.org/response-headers?Content-Type=application/vnd.whatever%2B
 # Content type is loosely matched, could be application/vnd.whatever+json
 GET http://httpbin.org/response-headers?Content-Type=application/something%2Bjson
 
+# Process pdf as binary: response is not modified and coding system set to no-conversion
+GET http://httpbin.org/response-headers?Content-Type=application/pdf
+
 # Returns PUT data.
 PUT http://httpbin.org/put
 Content-Type: application/json
@@ -150,6 +153,9 @@ POST http://httpbin.org/post?q=2
 # File upload
 PUT http://httpbin.org/put
 Content-type: text/plain
+
+# Test png image
+GET http://httpbin.org/image/png
 
 < /etc/passwd
 # Test for issue #121


### PR DESCRIPTION
When receiving binary data, do not decode it, put it in a buffer with coding-system set to no-conversion and do not dump the http header

Hello,
This is a fix proposal for the issue #140 

In a few words, I have added an alist from content-types to default encodings.
This allows to avoid transforming binary data. When binary data is received (say pdf), it is then possible to save the buffer to a file and open it with an external tool (eg: pdf reader). I have made it customizable so that users can specify other encoding if necessary.

Another change I have made is that when receiving binary data, I do not dump the HTTP headers into the response buffer because this could corrupt the data. This is a slight change to the existing processing of images: HTTP headers are no longer copied after the image. 
Users who still want to see the headers should call C-c C-r (raw mode) instead.

This is my first PR in github. Please do not hesitate to tell me if there is anything that you would like me to do differently.

Regards

Christophe
