### PR TITLE
Add byte-compiled files to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Byte-compiled files
+*.elc


### PR DESCRIPTION
This should prevent accidental commit of byte-compiled files
and make status more clear for users who obtains restclient.el
mode via Git submodules.