### PR TITLE
Chomp end of filename inclusion

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -20,6 +20,7 @@
 ;;
 (require 'url)
 (require 'json)
+(require 'cl-macs)
 
 (defgroup restclient nil
   "An interactive HTTP client for Emacs."
@@ -408,8 +409,13 @@ The buffer contains the raw HTTP response sent by the server."
 
 (defun restclient-read-file (path)
   (with-temp-buffer
-    (insert-file-contents path)
-    (buffer-string)))
+    (cl-flet ((chomp
+               (str)
+               (replace-regexp-in-string
+                (rx (* (any " \t\n")) eos)
+                "" str)))
+      (insert-file-contents (chomp path))
+      (buffer-string))))
 
 (defun restclient-parse-body (entity vars)
   (if (= 0 (or (string-match restclient-file-regexp entity) 1))


### PR DESCRIPTION
If the name of a file to include in a POST request isn't followed on the next line by an end-of-entity marker, the file inclusion fails because spurious new-lines are included. The following request, which had been failing due to `example_data.json` not being found, now succeeds where it prev:
```
POST $MY_URL
Content-Type: application/json

< example_data.json

#
```