### PR TITLE
Toggle the visibility of HTTP body

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -534,16 +534,16 @@ Optional argument STAY-IN-WINDOW do not move focus to response buffer if t."
     (when at-header
       (save-excursion
         (end-of-line)
-        ;; If the overlays at this point have 'invisible set, try to make
-        ;; the region visible. Else hide the region
-        ;; This part of code is from org-hide-block-toggle method of Org mode
+        ;; If the overlays at this point have 'invisible set, toggling
+        ;; must make the region visible. Else it must hide the region
+        
+        ;; This part of code is from org-hide-block-toggle method of
+        ;; Org mode
         (let ((overlays (overlays-at (point))))
           (if (memq t (mapcar
                        (lambda (o)
                          (eq (overlay-get o 'invisible) 'outline))
                        overlays))
-              ;; This means that currently the block is invisible and
-              ;; we've to make it visible
               (outline-flag-region (point) (restclient-current-max) nil)
             (outline-flag-region (point) (restclient-current-max) t)))))))
 

--- a/restclient.el
+++ b/restclient.el
@@ -580,7 +580,10 @@ Optional argument STAY-IN-WINDOW do not move focus to response buffer if t."
   (set (make-local-variable 'comment-column) 48)
 
   (set (make-local-variable 'font-lock-defaults) '(restclient-mode-keywords))
-  ;; We use outline's methods to toggle the visibility of the body
+  ;; We use outline-mode's method outline-flag-region to hide/show the
+  ;; body. As a part of it, it sets 'invisibility text property to
+  ;; 'outline. To get ellipsis, we need 'outline to be in
+  ;; buffer-invisibility-spec
   (add-to-invisibility-spec '(outline . t)))
 
 (provide 'restclient)


### PR DESCRIPTION
This branch adds a method `restclient-toggle-body-visibility` that hides the body of the HTTP request the point is at. If the body is hid, an ellipsis is put at the end of the request line. Calling the same method again shows the body.

In other words, this adds the behaviour of body-visibility-toggling from Org/Outline mode.

For example,

if the point is at `[X]` in the following snippet,

```
POST [X]http://httpbin.org/post
Content-Type: application/json

{
    "jql": "project = HSP",
    "startAt": 0,
    "maxResults": 15,
    "fields": [
        "summary",
        "status",
        "assignee"
    ]
}
```

and TAB is pressed (which calls `restclient-toggle-body-visibility`), the snippet becomes

```
POST [X]http://httpbin.org/post...
```
Pressing TAB again,
```
POST [X]http://httpbin.org/post
Content-Type: application/json

{
    "jql": "project = HSP",
    "startAt": 0,
    "maxResults": 15,
    "fields": [
        "summary",
        "status",
        "assignee"
    ]
}
```

I deal with files containing large number of requests and this makes dealing with them more manageable.