### PR TITLE
Added scratch buffer feature

### DIFF
--- a/restclient-scratch.el
+++ b/restclient-scratch.el
@@ -1,0 +1,42 @@
+;;; restclient-scratch.el --- scratch buffer for restclient.el
+;;
+;; Public domain.
+
+;; Author: Jens de Jong <jensdejong@protonmail.com>
+;; Maintainer: Pavel Kurnosov <pashky@gmail.com>
+;; Created: 17 Dec 2017
+;; Keywords: http scratch
+
+;; This file is not part of GNU Emacs.
+;; This file is public domain software. Do what you want.
+
+;;; Commentary:
+;;
+;; This is a companion to restclient.el to have a scratch buffer to write some experimental requests.  Inspired by Emacs's and Cider's scratch buffers.
+
+;;; Code:
+;;
+(defconst restclient-scratch-buffer-name "*restclient-scratch*")
+
+;;;###autoload
+(defun restclient-scratch ()
+  "Go to the scratch buffer named `restclient-scratch-buffer-name'."
+  (interactive)
+  (pop-to-buffer (restclient-find-or-create-scratch-buffer)))
+
+(defun restclient-find-or-create-scratch-buffer ()
+  "Find or create the scratch buffer."
+  (or (get-buffer restclient-scratch-buffer-name)
+      (restclient-create-scratch-buffer)))
+
+(defun restclient-create-scratch-buffer ()
+  "Create a new scratch buffer."
+  (with-current-buffer (get-buffer-create restclient-scratch-buffer-name)
+    (restclient-mode)
+    (insert "# -*- restclient -*-\n"
+            "# This buffer is for experimental restclient calls.\n\n")
+    (current-buffer)))
+
+(provide 'restclient-scratch)
+
+;;; restclient-scratch.el ends here

--- a/restclient.el
+++ b/restclient.el
@@ -18,6 +18,8 @@
 
 ;;; Code:
 ;;
+(require 'restclient-scratch)
+
 (require 'url)
 (require 'json)
 


### PR DESCRIPTION
Many times when I'm using restclient, I just want to try out some requests. I can imagine other users using it in the same way (please let me know). This feature makes it easier to do this by allowing users to create a scratch buffer with `restclient-scratch` on the spot.