### PR TITLE
Type and subtype in media types should be treated as case insensitive

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -236,7 +236,8 @@
                                                     (match-string-no-properties 1)
                                                     "/"
                                                     (match-string-no-properties 2))
-                                                   restclient-content-type-modes))))
+                                                   restclient-content-type-modes
+                                                   t))))
                         (forward-line)) 0)))
       (setq end-of-headers (point))
       (while (and (looking-at restclient-empty-line-regexp)


### PR DESCRIPTION
See [RFC 2616 - Section 3.7](https://tools.ietf.org/html/rfc2616#section-3.7)