### PR TITLE
Replace variables in file paths

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -452,7 +452,7 @@ The buffer contains the raw HTTP response sent by the server."
         (when (looking-at restclient-empty-line-regexp)
           (forward-line))
         (let* ((cmax (restclient-current-max))
-               (entity (restclient-parse-body (buffer-substring (min (point) cmax) cmax) vars))
+               (entity (restclient-parse-body (restclient-replace-all-in-string vars (buffer-substring (min (point) cmax) cmax)) vars))
                (url (restclient-replace-all-in-string vars url)))
           (apply func method url headers entity args))))))
 
@@ -549,7 +549,7 @@ Optional argument STAY-IN-WINDOW do not move focus to response buffer if t."
         (end-of-line)
         ;; If the overlays at this point have 'invisible set, toggling
         ;; must make the region visible. Else it must hide the region
-        
+
         ;; This part of code is from org-hide-block-toggle method of
         ;; Org mode
         (let ((overlays (overlays-at (point))))


### PR DESCRIPTION
This change allows to specify a filename as a variable, e.g.:

```shell
:test-file = ./test-data.json

# Process stuff
GET http://localhost:8000/process
Content-Type: application/json

< :test-file
```

This allows to easily switch between different payloads for the same
API with minimal efforts.