### PR TITLE
Support for setting variables from responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ and supports a few additional keypresses:
 - `C-c n n`: narrow to region of current request (including headers)
 - `TAB`: hide/show current request body, only if 
 - `C-c C-a`: show all collapsed regions
+- `C-c C-i`: show information on resclient variables at point
 
 The last two functions are implemented as `restclient-outline-mode` minor mode, which is activated by default via hook for major mode. Remove this hook using `(remove-hook 'restclient-mode-hook 'restclient-outline-mode)` if you don't wish to have this behaviour, or it clashes with any other binding for `TAB` like autocomplete. 
 
@@ -79,6 +80,9 @@ Query file example:
     #
     DELETE https://jira.atlassian.com/rest/api/2/version/20
 
+    # Set a variable to the value of your ip address using a jq expression
+    GET http://httpbin.org/ip
+    -> jq-set-var :my-ip .origin
 
 Lines starting with `#` are considered comments AND also act as separators.
 
@@ -136,6 +140,16 @@ and the body.
     :my-headers
 
     { "name": ":the-name" }
+
+Varaibles can also be set based on the body of a response using the per-request hooks
+
+    # set a variable :my-ip to the value of your ip address using a jq expression
+    GET http://httpbin.org/ip
+    -> jq-set-var :my-ip .origin
+	
+	# set a variable using elisp evaluated in the result buffer
+	GET http://httpbin.org/headers
+	-> run-hook (restclient-set-var ":my-var" (format "some %s" 'elisp))
 
 # File uploads
 

--- a/examples/httpbin
+++ b/examples/httpbin
@@ -30,8 +30,13 @@ Content-Type: application/json
     ]
 }
 
+
 # Content type is loosely matched, could be application/vnd.whatever+json
 GET http://httpbin.org/response-headers?Content-Type=application/vnd.whatever%2Bjson;%20charset=UTF-8
+-> on-response (message "dynamic hook called %s %s"
+(random ) (random ))
+-> on-response (message "another hook")
+
 
 # Content type is loosely matched, could be application/vnd.whatever+json
 GET http://httpbin.org/response-headers?Content-Type=application/something%2Bjson
@@ -123,9 +128,10 @@ POST http://httpbin.org/post
 #
 # Multiline variable referencing another variable
 #
+:my-ip = "123.1.1.1"
 :common-headers = <<
 Authentication: :auth-token
-User-Agent: MyApp/1.0
+User-Agent: MyApp/1.0 | Other app :my-ip
 Content-type: application/json
 #
 # ...and another one
@@ -171,3 +177,21 @@ GET http://httpbin.org/redirect-to?url=http%3A%2F%2Fexample.com%2F
 
 POST http://httpbin.org/post
 Cookie: :cookie
+
+# ================================================================================================
+# dynamic per-request hooks
+
+# multi-line elisp expression called on completion
+GET http://httpbin.org/response-headers?Content-Type=application/vnd.whatever%2Bjson;%20charset=UTF-8
+-> run-hook (message "dynamic hook called %s %s"
+                  (random ) (random ))
+
+# set a variable to the value of your ip address using a jq expression
+GET http://httpbin.org/ip
+-> jq-set-var :my-ip .origin
+
+# multiple elsip hooks on call
+GET http://httpbin.org/response-headers?Content-Type=application/vnd.whatever%2Bjson;%20charset=UTF-8
+-> run-hook (message "hook 1")
+-> run-hook (message "hook 2")
+

--- a/restclient-jq.el
+++ b/restclient-jq.el
@@ -1,0 +1,75 @@
+;;; restclient-jq.el --- support for setting resetclient vars from jq expressions
+;;
+;; Public domain.
+
+;; Author: Cameron Dorrat <cdorrat@gmail.com>
+;; Maintainer: Cameron Dorrat <cdorrat@gmail.com>
+;; Created: 26 Apr 2020
+;; Keywords: http jq
+;; Package-Requires: ((restclient "0") (jq-mode "0.4.1"))
+
+;; This file is not part of GNU Emacs.
+;; This file is public domain software. Do what you want.
+
+;;; Commentary:
+;;
+;; This is a companion to restclient.el to add support for setting variables from results using jq expressions
+
+;;; Code:
+;;
+(require 'jq-mode)
+
+
+;; --- jq support
+(defun restclient-result-end-point ()
+  (save-excursion
+    (goto-char (point-max))
+    (or (and (re-search-backward "^[^/].*" nil t)
+	     (line-end-position))
+	(point-max))))
+
+(defun restclient-jq-get-var (jq-pattern)
+  (with-temp-buffer
+    (let ((output (current-buffer)))
+      (with-current-buffer restclient-same-buffer-response-name
+        (call-process-region
+         (point-min)
+         (restclient-result-end-point)
+         shell-file-name
+         nil
+         output
+         nil
+         shell-command-switch
+         (format "%s %s %s"
+                 jq-interactive-command
+		 "-r"
+                 (shell-quote-argument jq-pattern))))      
+      (string-trim (buffer-string)))))
+
+(defun restclient-json-var-function (args args-offset)
+  (save-match-data
+   (and (string-match "\\(:[^: \n]+\\) \\(.*\\)$" args)
+	(lexical-let ((var-name (match-string 1 args))
+		      (jq-patt (match-string 2 args)))
+	  (lambda ()
+	    (let ((resp-val (restclient-jq-get-var jq-patt)))
+	      (restclient-remove-var var-name)
+	      (restclient-set-var var-name resp-val)
+	      (message "restclient var [%s = \"%s\"] " var-name resp-val)))))))
+
+(defun restclient-jq-interactive-result ()
+  (interactive)
+  (flush-lines "^//.*") ;; jq doesnt like comments
+  (jq-interactively (point-min) (restclient-result-end-point)))
+
+
+(provide 'restclient-jq)
+
+(eval-after-load 'restclient
+  '(progn
+     (resetclient-register-result-func
+      "jq-set-var" #'restclient-json-var-function
+      "Set a resetclient variable with the value jq expression, 
+       takes var & jq expression as args. 
+       eg. -> jq-set-var :my-token .token")
+     (define-key restclient-response-mode-map  (kbd "C-c C-j") #'restclient-jq-interactive-result)))


### PR DESCRIPTION
Hi, 
  here's a pull request that adds support for setting variables from responses, it's useful for things like hitting an auth endpoint to get a token.

It's implemented by adding support for per request hooks and an api for setting variables. 
It currently supports running elisp hooks & setting variables from jq expressions if jq-mode is installed
but can be easily extended (in restclient itself or by the end user).

Let me know what you think,
  Cameron.