### PR TITLE
Add more useful Elisp example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,13 @@ and the body.
 
 Varaibles can also be set based on the body of a response using the per-request hooks
 
-    # set a variable :my-ip to the value of your ip address using a jq expression
+    # set a variable :my-ip to the value of your ip address using elisp evaluated in the result buffer
     GET http://httpbin.org/ip
-    -> jq-set-var :my-ip .origin
-	
-	# set a variable using elisp evaluated in the result buffer
-	GET http://httpbin.org/headers
-	-> run-hook (restclient-set-var ":my-var" (format "some %s" 'elisp))
+    -> run-hook (restclient-set-var ":my-ip" (cdr (assq 'origin (json-read))))
+    
+    # set a variable :my-var using a more complex jq expression (requires jq-mode)
+    GET https://httpbin.org/json
+    -> jq-set-var :my-var .slideshow.slides[0].title
 
 # File uploads
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ Varaibles can also be set based on the body of a response using the per-request 
     GET http://httpbin.org/ip
     -> run-hook (restclient-set-var ":my-ip" (cdr (assq 'origin (json-read))))
     
+    # same thing with jq if it's installed
+    GET http://httpbin.org/ip 
+    -> jq-set-var :my-ip .origin
+    
     # set a variable :my-var using a more complex jq expression (requires jq-mode)
     GET https://httpbin.org/json
     -> jq-set-var :my-var .slideshow.slides[0].title


### PR DESCRIPTION
Thanks for making this and adding the useful request hook functionality recently.

I wanted to set variables from JSON responses, but can't install jq on my work computer. After playing around  a bit, I found that using the built-in `json-read` is works nicely and is still quite readable for simple parsing.

This PR updates the README to add an example of parsing using Elisp so other users can see how the new request-hooks can still be useful without installing jq or jq-mode.