### PR TITLE
fixes #236: README.md: update POST example "HSP" => "HCPUB"

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Query file example:
     Content-Type: application/json
 
     {
-            "jql": "project = HSP",
+            "jql": "project = HCPUB",
             "startAt": 0,
             "maxResults": 15,
             "fields": [


### PR DESCRIPTION
The "HSP" project is no longer available at the upstream jira.atlassian.com
host, so the POST example that used that project name in the 'jql' query
stopped working. This change simply replaces "HSP" with "HCPUB", which is a
project ("HipChat") that is still available at that location, so restores the
example to working order.