### PR TITLE
fix two remaining "resetclient" typos

### DIFF
--- a/restclient-jq.el
+++ b/restclient-jq.el
@@ -1,4 +1,4 @@
-;;; restclient-jq.el --- Support for setting resetclient vars from jq expressions
+;;; restclient-jq.el --- Support for setting restclient vars from jq expressions
 ;;
 ;; Public domain.
 

--- a/restclient.el
+++ b/restclient.el
@@ -562,10 +562,10 @@ The buffer contains the raw HTTP response sent by the server."
     (lambda ()
       (eval form))))
 
-(resetclient-register-result-func
+(restclient-register-result-func
  "run-hook" #'restclient-elisp-result-function
- "Call the provided (possibly multi-line) elisp when the result 
-  buffer is formatted. Equivalent to a restclient-response-loaded-hook 
+ "Call the provided (possibly multi-line) elisp when the result
+  buffer is formatted. Equivalent to a restclient-response-loaded-hook
   that only runs for this request.
   eg. -> on-response (message \"my hook called\")" )
 


### PR DESCRIPTION
Yesterday's changes broke the package due to these two hanging references, but this has it working for me now