### PR TITLE
Allow file reading in the middle of request body

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -459,10 +459,16 @@ The buffer contains the raw HTTP response sent by the server."
     (insert-file-contents path)
     (buffer-string)))
 
+(defun restclient-replace-path-with-contents (entity)
+  (replace-regexp-in-string
+   restclient-file-regexp
+   (lambda (match)
+     (string-match restclient-file-regexp match)
+     (restclient-read-file (match-string 1 match)))
+   entity))
+
 (defun restclient-parse-body (entity vars)
-  (if (= 0 (or (string-match restclient-file-regexp entity) 1))
-      (restclient-read-file (match-string 1 entity))
-    (restclient-replace-all-in-string vars entity)))
+  (restclient-replace-path-with-contents (restclient-replace-all-in-string vars entity)))
 
 (defun restclient-parse-hook (cb-type args-offset args)
   (if-let ((handler (assoc cb-type restclient-result-handlers)))


### PR DESCRIPTION
IMHO the regular expression to match the pattern is strict enough that in few cases will this collide with real body contents, and this enables more intuitive body construction, especially when uploading files with `multipart/form-data`. Futhermore, this should also allow variable substitution in file paths.