### PR TITLE
fix: requests can be indented ( by spaces or tabs)

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -171,7 +171,7 @@
 (defconst restclient-empty-line-regexp "^\\s-*$")
 
 (defconst restclient-method-url-regexp
-  "^\\(GET\\|POST\\|DELETE\\|PUT\\|HEAD\\|OPTIONS\\|PATCH\\) \\(.*\\)$")
+  "^[[:blank:]]*\\(GET\\|POST\\|DELETE\\|PUT\\|HEAD\\|OPTIONS\\|PATCH\\) \\(.*\\)$")
 
 (defconst restclient-header-regexp
   "^\\([^](),/:;@[\\{}= \t]+\\): \\(.*\\)$")


### PR DESCRIPTION
The regexp in `restclient-method-url-regexp` can be modified to support REST requests that start with spaces or tabs. Before this commit, if a request starts with a space, it will fail.

@pashky, do you think this "feature" makes sense? This allows me to indent my requests in, for example, org buffers. 