### PR TITLE
Update README with example of hook on POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ Varaibles can also be set based on the body of a response using the per-request 
     # set a variable :my-var using a more complex jq expression (requires jq-mode)
     GET https://httpbin.org/json
     -> jq-set-var :my-var .slideshow.slides[0].title
+    
+    # hooks come before the body on POST
+    POST http://httpbin.org/post
+    -> jq-set-var :test .json.test
+
+    {"test": "foo"}
 
 # File uploads
 


### PR DESCRIPTION
The only existing examples are for GET and don't have a body. My first thought was that the hook would go below the entire request, but that just added it to the body. By trial and error, I discovered that the hook goes here.

This example clarifies where the hook goes if you want to POST.