### PR TITLE
Require subr-x and cl package explicitly

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -6,7 +6,6 @@
 ;; Maintainer: Pavel Kurnosov <pashky@gmail.com>
 ;; Created: 01 Apr 2012
 ;; Keywords: http
-;; Package-Requires: ((cl-lib "0.5"))
 
 ;; This file is not part of GNU Emacs.
 ;; This file is public domain software. Do what you want.
@@ -22,7 +21,8 @@
 (require 'url)
 (require 'json)
 (require 'outline)
-(require 'cl-lib)
+(eval-when-compile (require 'subr-x))
+(eval-when-compile (require 'cl))
 
 (defgroup restclient nil
   "An interactive HTTP client for Emacs."

--- a/restclient.el
+++ b/restclient.el
@@ -6,6 +6,7 @@
 ;; Maintainer: Pavel Kurnosov <pashky@gmail.com>
 ;; Created: 01 Apr 2012
 ;; Keywords: http
+;; Package-Requires: ((cl-lib "0.5"))
 
 ;; This file is not part of GNU Emacs.
 ;; This file is public domain software. Do what you want.
@@ -21,6 +22,7 @@
 (require 'url)
 (require 'json)
 (require 'outline)
+(require 'cl-lib)
 
 (defgroup restclient nil
   "An interactive HTTP client for Emacs."


### PR DESCRIPTION
Emacs 28 doesn't seem to load `'cl` by default which breaks the `run-hook` as describe in #248