### PR TITLE
'cl is deprecated in emacs 27 and beyond

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -22,7 +22,11 @@
 (require 'json)
 (require 'outline)
 (eval-when-compile (require 'subr-x))
-(eval-when-compile (require 'cl))
+(eval-when-compile
+  (when (version< emacs-version "26")
+    (require 'cl)))
+
+(eval-when-compile (require 'cl-lib))
 
 (defgroup restclient nil
   "An interactive HTTP client for Emacs."

--- a/restclient.el
+++ b/restclient.el
@@ -23,10 +23,9 @@
 (require 'outline)
 (eval-when-compile (require 'subr-x))
 (eval-when-compile
-  (when (version< emacs-version "26")
-    (require 'cl)))
-
-(eval-when-compile (require 'cl-lib))
+  (if (version< emacs-version "26")
+      (require 'cl)
+    (require 'cl-lib)))
 
 (defgroup restclient nil
   "An interactive HTTP client for Emacs."


### PR DESCRIPTION
the previously common practice of rquiring 'cl now throws a
deprecation warning. Update the package requirements to cl-lib.