### PR TITLE
Added restclient-http-send-current-suppress-response-buffer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ and supports a few additional keypresses:
 - `C-c C-c`: runs the query under the cursor, tries to pretty-print the response (if possible)
 - `C-c C-r`: same, but doesn't do anything with the response, just shows the buffer
 - `C-c C-v`: same as `C-c C-c`, but doesn't switch focus to other window
+- `C-c C-b`: same as `C-c C-c`, but doesn't show response buffer
 - `C-c C-p`: jump to the previous query
 - `C-c C-n`: jump to the next query
 - `C-c C-.`: mark the query under the cursor

--- a/restclient.el
+++ b/restclient.el
@@ -339,7 +339,7 @@
     (while (re-search-forward "\\\\[Uu]\\([0-9a-fA-F]\\{4\\}\\)" nil t)
       (replace-match (char-to-string (decode-char 'ucs (string-to-number (match-string 1) 16))) t nil))))
 
-(defun restclient-http-handle-response (status method url bufname raw stay-in-window)
+(defun restclient-http-handle-response (status method url bufname raw stay-in-window suppress-response-buffer)
   "Switch to the buffer returned by `url-retreive'.
 The buffer contains the raw HTTP response sent by the server."
   (setq restclient-within-call nil)
@@ -357,9 +357,10 @@ The buffer contains the raw HTTP response sent by the server."
         (buffer-enable-undo)
 	(restclient-response-mode)
         (run-hooks 'restclient-response-loaded-hook)
-        (if stay-in-window
-            (display-buffer (current-buffer) t)
-          (switch-to-buffer-other-window (current-buffer)))))))
+        (unless suppress-response-buffer
+          (if stay-in-window
+              (display-buffer (current-buffer) t)
+            (switch-to-buffer-other-window (current-buffer))))))))
 
 (defun restclient-decode-response (raw-http-response-buffer target-buffer-name same-name)
   "Decode the HTTP response using the charset (encoding) specified in the Content-Type header. If no charset is specified, default to UTF-8."
@@ -581,12 +582,12 @@ The buffer contains the raw HTTP response sent by the server."
   eg. -> on-response (message \"my hook called\")" )
 
 ;;;###autoload
-(defun restclient-http-send-current (&optional raw stay-in-window)
+(defun restclient-http-send-current (&optional raw stay-in-window suppress-response-buffer)
   "Sends current request.
 Optional argument RAW don't reformat response if t.
 Optional argument STAY-IN-WINDOW do not move focus to response buffer if t."
   (interactive)
-  (restclient-http-parse-current-and-do 'restclient-http-do raw stay-in-window))
+  (restclient-http-parse-current-and-do 'restclient-http-do raw stay-in-window suppress-response-buffer))
 
 ;;;###autoload
 (defun restclient-http-send-current-raw ()
@@ -599,6 +600,12 @@ Optional argument STAY-IN-WINDOW do not move focus to response buffer if t."
   "Send current request and keep focus in request window."
   (interactive)
   (restclient-http-send-current nil t))
+
+;;;###autoload
+(defun restclient-http-send-current-suppress-response-buffer ()
+  "Send current request but don't show response buffer."
+  (interactive)
+  (restclient-http-send-current nil nil t))
 
 (defun restclient-jump-next ()
   "Jump to next request in buffer."
@@ -744,6 +751,7 @@ Optional argument STAY-IN-WINDOW do not move focus to response buffer if t."
     (define-key map (kbd "C-c C-c") 'restclient-http-send-current)
     (define-key map (kbd "C-c C-r") 'restclient-http-send-current-raw)
     (define-key map (kbd "C-c C-v") 'restclient-http-send-current-stay-in-window)
+    (define-key map (kbd "C-c C-b") 'restclient-http-send-current-suppress-response-buffer)
     (define-key map (kbd "C-c C-n") 'restclient-jump-next)
     (define-key map (kbd "C-c C-p") 'restclient-jump-prev)
     (define-key map (kbd "C-c C-.") 'restclient-mark-current)


### PR DESCRIPTION
This command will send current request as usual but it will not display response buffer.

Motivation: When running http server in the `*shell*` or in `comint` etc. I want to observe log output in that buffer as http request is being processed.