### PR TITLE
Prepare restclient jq for inclusion in MELPA

### DIFF
--- a/restclient-jq.el
+++ b/restclient-jq.el
@@ -46,7 +46,7 @@
                  (shell-quote-argument jq-pattern))))
       (string-trim (buffer-string)))))
 
-(defun restclient-jq-json-var-function (args args-offset)
+(defun restclient-jq-json-var-function (args _args-offset)
   (save-match-data
     (and (string-match "\\(:[^: \n]+\\) \\(.*\\)$" args)
          (let ((var-name (match-string 1 args))

--- a/restclient-jq.el
+++ b/restclient-jq.el
@@ -19,6 +19,7 @@
 
 ;;; Code:
 ;;
+(require 'restclient)
 (require 'jq-mode)
 
 ;; --- jq support
@@ -70,19 +71,12 @@ ARGS contains the variable name and a jq pattern to use."
   (flush-lines "^//.*") ;; jq doesnt like comments
   (jq-interactively (point-min) (restclient-jq-result-end-point)))
 
-
-(provide 'restclient-jq)
-
-;; todo: eval-after-load should be used in configuration, not
-;; packages. Replace with a better solution.
-(eval-after-load 'restclient
-  '(progn
-     (restclient-register-result-func
-      "jq-set-var" #'restclient-jq-json-var-function
-      "Set a restclient variable with the value jq expression,
-       takes var & jq expression as args.
-       eg. -> jq-set-var :my-token .token")
-     (define-key restclient-response-mode-map  (kbd "C-c C-j") #'restclient-jq-interactive-result)))
+(restclient-register-result-func
+ "jq-set-var" #'restclient-jq-json-var-function
+ "Set a restclient variable with the value jq expression,
+takes var & jq expression as args.
+eg. -> jq-set-var :my-token .token")
+(define-key restclient-response-mode-map  (kbd "C-c C-j") #'restclient-jq-interactive-result)
 
 (provide 'restclient-jq)
 

--- a/restclient-jq.el
+++ b/restclient-jq.el
@@ -6,7 +6,8 @@
 ;; Author: Cameron Dorrat <cdorrat@gmail.com>
 ;; Maintainer: Cameron Dorrat <cdorrat@gmail.com>
 ;; Created: 26 Apr 2020
-;; Keywords: http jq
+;; Keywords: tools comm http jq
+;; Version: 0.1
 ;; Package-Requires: ((restclient "20200502.831") (jq-mode "0.4.1") (emacs "24.4"))
 
 ;; This file is not part of GNU Emacs.

--- a/restclient-jq.el
+++ b/restclient-jq.el
@@ -22,6 +22,7 @@
 
 ;; --- jq support
 (defun restclient-jq-result-end-point ()
+  "Find the end of a restclient JSON response body."
   (save-excursion
     (goto-char (point-max))
     (or (and (re-search-backward "^[^/].*" nil t)
@@ -29,6 +30,8 @@
 	(point-max))))
 
 (defun restclient-jq-get-var (jq-pattern)
+  "Find value matching the JQ-PATTERN in a restclient JSON response."
+
   (with-temp-buffer
     (let ((output (current-buffer)))
       (with-current-buffer restclient-same-buffer-response-name
@@ -47,6 +50,9 @@
       (string-trim (buffer-string)))))
 
 (defun restclient-jq-json-var-function (args _args-offset)
+  "A restclient result func for setting variables from a JSON response.
+
+ARGS contains the variable name and a jq pattern to use."
   (save-match-data
     (and (string-match "\\(:[^: \n]+\\) \\(.*\\)$" args)
          (let ((var-name (match-string 1 args))
@@ -58,6 +64,7 @@
                (message "restclient var [%s = \"%s\"] " var-name resp-val)))))))
 
 (defun restclient-jq-interactive-result ()
+  "Run jq interactively on a restclient JSON response buffer."
   (interactive)
   (flush-lines "^//.*") ;; jq doesnt like comments
   (jq-interactively (point-min) (restclient-jq-result-end-point)))


### PR DESCRIPTION
I'm trying to get `restclient-jq` into MELPA, see the [corresponding pull request](https://github.com/melpa/melpa/pull/7982). At MELPA, there is a checklist of automated tests that are supposed to pass before a new package can be included. Here are the relevant bits of MELPA's checklist:

- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings