### PR TITLE
Display request in fundamental mode if it's too big

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ __Default: nil__
 
 Inhibit restclient from sending cookies implicitly.
 
+### restclient-response-size-threshold
+
+__Default: 100000__
+
+Size of the response buffer restclient can display without huge performance dropdown.
+If response buffer will be more than that, only bare major mode will be used to display it.
+Set to `nil` to disable threshold completely.
+
 # Known issues
 
 - Comment lines `#` act as end of entity. Yes, that means you can't post shell script or anything with hashes as PUT/POST entity. I'm fine with this right now,


### PR DESCRIPTION
This PR added feature to use `fundamental-mode` when response, received by restclient, is too big (from personal experience, receiving 13kk symbols knocked out my emacs for 5 minutes). Threshold can be tuned via variable (not sure about it's default value though). PR fixes https://github.com/pashky/restclient.el/issues/285