### PR TITLE
Add support for variable substitution in elisp expressions

### DIFF
--- a/examples/httpbin
+++ b/examples/httpbin
@@ -83,6 +83,13 @@ Cookie: name=restclient
 GET http://httpbin.org/basic-auth/user/password
 Authorization: :example-auth
 
+# HTTPBasic Auth with Variables
+:username  = user
+:password  = password
+:basicauth := (format "Basic %s" (base64-encode-string (format "%s:%s" ":username" ":password")))
+GET http://httpbin.org/basic-auth/user/password
+Authorization: :basicauth
+
 # Returns some XML
 GET http://httpbin.org/xml
 

--- a/restclient.el
+++ b/restclient.el
@@ -471,11 +471,12 @@ The buffer contains the raw HTTP response sent by the server."
         (let ((name (match-string-no-properties 1))
               (should-eval (> (length (match-string 2)) 0))
               (value (or (restclient-chop (match-string-no-properties 4)) (match-string-no-properties 3))))
-          (setq vars (cons (cons name (if should-eval (restclient-eval-var value) value)) vars))))
+          (setq vars (cons (cons name (if should-eval (restclient-eval-var value vars) value)) vars))))
       (append restclient-var-overrides vars))))
 
-(defun restclient-eval-var (string)
-  (with-output-to-string (princ (eval (read string)))))
+(defun restclient-eval-var (value vars)
+  (let ((input (restclient-replace-all-in-string vars value)))
+    (with-output-to-string (princ (eval (read input))))))
 
 (defun restclient-make-header (&optional string)
   (cons (match-string-no-properties 1 string)


### PR DESCRIPTION
Currently, variable substitution does not happen in ELisp expressions. The recommended method is to use setq.

This Pull Request adds support for variable substitution in the ELisp expressions as well.