### PR TITLE
restclient-jq is documented, instead of jq-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Varaibles can also be set based on the body of a response using the per-request 
     GET http://httpbin.org/ip 
     -> jq-set-var :my-ip .origin
     
-    # set a variable :my-var using a more complex jq expression (requires jq-mode)
+    # set a variable :my-var using a more complex jq expression (requires restclient-jq)
     GET https://httpbin.org/json
     -> jq-set-var :my-var .slideshow.slides[0].title
     


### PR DESCRIPTION
The manual states that `jq-mode` is required by `jq-set-var`, but I think that the right package to import is `restclient-jq` instead.